### PR TITLE
Add sitemap.xml to robots.txt

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,3 +1,5 @@
 # allow crawling everything by default
 User-agent: *
 Disallow:
+
+Sitemap: https://openpubliceren.nl/sitemap.xml


### PR DESCRIPTION
See:
- [RFC9309 - Robots Exclusion Protocol -  § 2.2.4. Other Records](https://datatracker.ietf.org/doc/html/rfc9309#name-other-records)
- [Sitemaps XML format - Informing search engine crawlers - Specifying the Sitemap location in your `robots.txt` file](https://www.sitemaps.org/protocol.html#submit_robots):
     > add the following line including _the full URL_ to the sitemap
     Also stated by https://stackoverflow.com/a/14218476

Note it would be better to use a `$DOMAIN` / environment variable being substituted (e.g. with `envsubst`). But currently that is not a variable, and hardcoded:
- https://github.com/openstate/open-publiceren-v2/blob/f892ee2687885b3c7ee7a1c971a782a76abebcc3/static/.well-known/security.txt#L4
- https://github.com/openstate/open-publiceren-v2/blob/f892ee2687885b3c7ee7a1c971a782a76abebcc3/src/app.html#L12

Since the full URL (so also the domain) is needed, it's also hardcoded in this case.